### PR TITLE
Update metadata block

### DIFF
--- a/src/meta.js
+++ b/src/meta.js
@@ -5,7 +5,7 @@
 // @description     $inline('pkg:description')
 // @author          $inline('pkg:author,name')
 // @license         $inline('pkg:license')
-// @homepage        $inline('pkg:homepage')
+// @homepageURL     $inline('pkg:homepage')
 // @supportURL      $inline('pkg:bugs,url')
 // @include         /^https:\/\/(?:ipv4|ipv6|www)\.google\.(?:[a-z\.]+)\/search\?(?:.+&)?q=[^&]+(?:&.+)?$/
 // @exclude         /^https:\/\/(?:ipv4|ipv6|www)\.google\.(?:[a-z\.]+)\/search\?(?:.+&)?tbm=lcl(?:&.+)?$/

--- a/src/meta.js
+++ b/src/meta.js
@@ -7,8 +7,8 @@
 // @license         $inline('pkg:license')
 // @homepage        $inline('pkg:homepage')
 // @supportURL      $inline('pkg:bugs,url')
-// @include         https://www.google.*/search?*
-// @include         https://www.google.*/webhp?*
+// @include         /^https:\/\/(?:ipv4|ipv6|www)\.google\.(?:[a-z\.]+)\/search\?(?:.+&)?q=[^&]+(?:&.+)?$/
+// @exclude         /^https:\/\/(?:ipv4|ipv6|www)\.google\.(?:[a-z\.]+)\/search\?(?:.+&)?tbm=lcl(?:&.+)?$/
 // @compatible      firefox
 // @compatible      chrome
 // @compatible      opera

--- a/src/meta.js
+++ b/src/meta.js
@@ -11,6 +11,7 @@
 // @exclude         /^https:\/\/(?:ipv4|ipv6|www)\.google\.(?:[a-z\.]+)\/search\?(?:.+&)?tbm=lcl(?:&.+)?$/
 // @compatible      firefox
 // @compatible      chrome
+// @compatible      edge
 // @compatible      opera
 // @run-at          document-end
 // @grant           GM_getValue


### PR DESCRIPTION
This pull request updates the metadata block of UserJS and UserCSS.

- [x] Remove old `www.google.*/webhp` URL. (a068a96e254aa494291f75899c9dba72a8c16128)
- [x] Support `ipv4.google.com` and `ipv6.google.com` domains. (a068a96e254aa494291f75899c9dba72a8c16128)
- [x] Exclude location search page. (Fix #45) (a068a96e254aa494291f75899c9dba72a8c16128)
- [x] Change `@homepage` to `@homepageURL` because Greasemonkey only accepts the later. (265b15bb564e85a3aef3490a9739038e92e0ed6f)
- [x] Flag the UserJS as compatible with Microsoft Edge on Greasy Fork. (99799b0d4bd9272e32125080f3fb00ffadbddd6f)
