### PR TITLE
Add dark theme support

### DIFF
--- a/src/css/modal-dark.css
+++ b/src/css/modal-dark.css
@@ -1,0 +1,26 @@
+/*!
+ * Configuration Modal CSS (Dark Theme)
+ */
+
+.gm-region-modal {
+  background-color: rgba(32,33,36,0.75);
+  color: #bdc1c6;
+}
+
+.gm-region-modal-dialog {
+  box-shadow: 0 4px 16px rgba(0,0,0,0.8);
+  border: 1px solid #313437;
+  background: #202124;
+}
+
+.gm-region-modal-close {
+  filter: invert(100%);
+}
+
+.gm-region-control-indicator {
+  border: 1px solid #5f6368;
+}
+
+.gm-region-control-indicator::after {
+  filter: invert(100%);
+}

--- a/src/user.js
+++ b/src/user.js
@@ -400,13 +400,23 @@ function delegateEvents () {
  * @return {Promise<HTMLStyleElement>}
  */
 function addStyles () {
-  const style = addStyle(`
+  addStyle(`
     $inline('css:menu,4')
     $inline('css:modal,4')
     $inline('css:flags,4')
   `)
 
-  return Promise.resolve(style)
+  if (
+    window
+      .getComputedStyle(document.body)
+      .getPropertyValue('background-color') !== 'rgb(255, 255, 255)'
+  ) {
+    addStyle(`
+      $inline('css:modal-dark,4')
+    `)
+  }
+
+  return Promise.resolve(true)
 }
 
 // =============================================================================


### PR DESCRIPTION
This pull request adds a dark theme style and automatically enables it when Google search is in the dark theme, depending on the page background color.
